### PR TITLE
Add project discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-migrate-tools"
-version = "0.1.2"
+version = "0.1.3"
 description = "LLM-powered code migrations at scale"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/ai_migrate/cli.py
+++ b/src/ai_migrate/cli.py
@@ -30,6 +30,7 @@ from prompt_toolkit import prompt
 from prompt_toolkit.completion import PathCompleter
 
 from ai_migrate.git import get_branches, get_worktrees
+from ai_migrate.projects_root import get_project_dir
 from .pr_utils import (
     setup_project_from_pr,
     get_pr_details,
@@ -636,9 +637,13 @@ def init(interactive):
 
 
 def project_dir_option(f):
-    def project_dir_validate(_ctx, param, project_dir):
-        if param.name == "project_dir" and project_dir:
-            project_dir = Path(__file__).parent.parent.parent / "projects" / project_dir
+    def project_dir_validate(ctx, param, project_dir):
+        if "project_dir" in ctx.params:
+            return ctx.params["project_dir"]
+
+        if "--project" in param.opts:
+            project_dir = get_project_dir(project_dir)
+            return project_dir
 
         if not project_dir:
             project_dir = os.environ.get("AI_MIGRATE_PROJECT_DIR")
@@ -938,6 +943,13 @@ def script(script, project_dir):
 
     console.print(f"Running script: [bold cyan]{script_path}[/bold cyan]")
     subprocess.run(command, check=True)
+
+
+@cli.command()
+@project_dir_option
+def current_project(project_dir):
+    """Show the project directory."""
+    console.print(f"Project directory: [bold cyan]{project_dir}[/bold cyan]")
 
 
 def main():

--- a/src/ai_migrate/projects.py
+++ b/src/ai_migrate/projects.py
@@ -11,12 +11,10 @@ from ai_migrate.git import get_branches
 from .manifest import (
     FileEntry,
     Manifest,
-    SYSTEM_PROMPT_FILE,
-    VERIFY_SCRIPT_FILE,
     FileGroup,
     Directory,
 )
-from .migrate import run as run_migration, SYSTEM_MESSAGE, FailedPreVerification
+from .migrate import run as run_migration, FailedPreVerification
 from .progress import StatusManager
 
 
@@ -199,53 +197,6 @@ async def run(
 
     print(f"Results saved to {results_file}")
     return results
-
-
-def init(
-    path: str, pr: str = None, description: str = None, file_extension: str = "java"
-):
-    """Initialize a new AI migration project at the specified path.
-
-    Args:
-        path: Path where the project should be created
-        pr: Optional PR number to use as a basis for the project
-        description: Optional short description of the migration task
-        file_extension: File extension for the migrated files
-    """
-    project_dir = Path(path).expanduser()
-
-    if pr:
-        # Use PR-based initialization if PR number is provided
-        if not description:
-            description = "Code migration task"
-
-        import asyncio
-        from .pr_utils import setup_project_from_pr
-
-        asyncio.run(setup_project_from_pr(pr, path, description, file_extension))
-        return
-
-    # Traditional initialization
-    if project_dir.exists() and any(project_dir.iterdir()):
-        raise ValueError(f"Directory {project_dir} already exists and is not empty")
-    project_dir.mkdir(exist_ok=True)
-    for child in (
-        "evals",
-        "examples",
-    ):
-        (project_dir / child).mkdir(exist_ok=True)
-        print(f"Created {project_dir / child}")
-
-    system_prompt = project_dir / SYSTEM_PROMPT_FILE
-    system_prompt.write_text(SYSTEM_MESSAGE)
-    print("Created default system prompt at", system_prompt)
-
-    verify_script = project_dir / VERIFY_SCRIPT_FILE
-    verify_script.touch()
-    print("Created empty verify script at", verify_script)
-
-    print("To make this your default project,")
-    print(f"    export AI_MIGRATE_PROJECT_DIR={project_dir.resolve()}")
 
 
 def verify(project_dir: str, files: Iterable[str], manifest_file: str | None):

--- a/src/ai_migrate/projects_root.py
+++ b/src/ai_migrate/projects_root.py
@@ -1,0 +1,45 @@
+from importlib.metadata import entry_points
+
+from pathlib import Path
+from typing import Iterable
+
+
+class ProjectsRoot:
+    def __init__(self, root_dir: Path | str):
+        self.root_dir = Path(root_dir)
+
+    def list_projects(self) -> Iterable[Path]:
+        if not self.root_dir.exists() or not self.root_dir.is_dir():
+            return []
+        for p in self.root_dir.iterdir():
+            if p.is_dir():
+                yield p
+
+
+_ROOTS = [
+    ProjectsRoot(Path("~/ai-migrator-projects").expanduser()),
+]
+_EXTRA_ROOTS_LOADED = False
+
+
+def _load_roots():
+    global _EXTRA_ROOTS_LOADED
+    for ep in entry_points(group="ai_migrate").select(name="projects_root"):
+        roots = ep.load()
+        if hasattr(roots, "__iter__"):
+            _ROOTS.extend(roots)
+        else:
+            _ROOTS.append(roots)
+    _EXTRA_ROOTS_LOADED = True
+
+
+def get_project_dir(name: str) -> Path:
+    if not _EXTRA_ROOTS_LOADED:
+        _load_roots()
+    for root in _ROOTS:
+        for project in root.list_projects():
+            if project.name == name:
+                return project
+    raise FileNotFoundError(
+        f"Project {name} not found in project roots [{', '.join(str(r.root_dir) for r in _ROOTS)}]"
+    )

--- a/src/ai_migrate/run_eval.py
+++ b/src/ai_migrate/run_eval.py
@@ -144,8 +144,8 @@ def run_project_eval(project, verbose=False):
                     "--manifest-file",
                     str(manifest_file),
                     "--local-worktrees",
-                    "--project",
-                    project,
+                    "--project-dir",
+                    str(project_dir),
                 ]
                 if (fakes_directory := directory / "llm-fakes").exists():
                     command.extend(["--llm-fakes", str(fakes_directory)])

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "ai-migrate-tools"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Loading based on `__file__` works OK in development, but not so well when the tool is installed. This makes things more explicit and also configurable.

By default we'll always look for projects in `~/ai-migrator-projects`, and allow users to plug in additional locations to search.